### PR TITLE
Column chart с подгрузкой данных через fetch

### DIFF
--- a/07-async-code-fetch-api-part-1/1-column-chart/index.js
+++ b/07-async-code-fetch-api-part-1/1-column-chart/index.js
@@ -3,5 +3,127 @@ import fetchJson from './utils/fetch-json.js';
 const BACKEND_URL = 'https://course-js.javascript.ru';
 
 export default class ColumnChart {
+  subElements = {};
+  chartHeight = 50;
 
+  constructor({
+                url = '',
+                range = {},
+                data = [],
+                label = '',
+                value = 0,
+                link = '',
+                formatHeading = (data) => data
+              } = {}) {
+    this.url = url;
+    this.range = range;
+    this.data = data;
+    this.label = label;
+    this.value = formatHeading(value);
+    this.link = link;
+    this.render();
+    this.update(range.from, range.to)
+  }
+
+  getChartBody(data) { //функция для генерации html кода для колонок chart-а
+    const maxValue = Math.max(...data);
+    const maxColumnHeight = this.chartHeight;
+    const scale = maxColumnHeight / maxValue;
+
+    const columnsHtml = data.map(value => {
+      let chartValue = Math.floor(value * scale);
+      let percentage = ((value / maxValue) * 100).toFixed(0);
+      return `<div style="--value: ${chartValue}" data-tooltip="${percentage}%"></div>`;
+    }).join('');
+
+    return columnsHtml;
+  }
+
+  getTemplate() {
+    const label = this.label;
+    const link = this.link ? `<a href="${this.link}" class="column-chart__link">View all</a>` : '';
+    const value = this.value;
+
+    const columnsHtml = this.data.length ? this.getChartBody(this.data) : '';
+
+    return `
+    <div class="column-chart column-chart_loading" style="--chart-height: 50">
+      <div class="column-chart__title">
+        ${label}
+        ${link}
+      </div>
+      <div class="column-chart__container">
+        <div data-element="header" class="column-chart__header">${value}</div>
+        <div data-element="body" class="column-chart__chart">
+        ${columnsHtml}
+        </div>
+       </div>
+     </div>
+    `;
+  }
+
+  render() {
+    const wrapper = document.createElement('div');
+
+    wrapper.innerHTML = this.getTemplate();
+
+    this.element = wrapper.firstElementChild;
+
+    if (this.data.length) {
+      if (this.element.classList.contains('column-chart_loading')) {
+        this.element.classList.remove('column-chart_loading');
+      }
+    }
+
+    this.subElements = this.getSubElements();
+  }
+
+  getSubElements() {
+    const result = {};
+    const elements = this.element.querySelectorAll('[data-element]');
+
+    for (const subElement of elements) {
+      const name = subElement.dataset.element;
+
+      result[name] = subElement;
+    }
+
+    return result;
+  }
+
+  remove() {
+    this.element.remove();
+  }
+
+  destroy() { //пока нет зависимостей, поэтому просто вызываем remove
+    this.remove();
+  }
+
+  rerender() {
+    const chartContainer = this.subElements.body;
+    chartContainer.innerHTML = this.getChartBody(this.data);
+
+    const dashboardElement = chartContainer.parentNode.parentNode; //нужно проверить у dashboard класслист
+
+    if (this.data.length) {
+      if (dashboardElement.classList.contains('column-chart_loading')) {
+        dashboardElement.classList.remove('column-chart_loading');
+      }
+      this.subElements.body.innerHTML = this.getChartBody(this.data);
+    } else {
+      dashboardElement.classList.add('column-chart_loading');
+      this.subElements.body.innerHTML = '';
+    }
+  }
+
+  update(startDate, endDate) {
+    const params = {'from': startDate, 'to': endDate}; //`?from=${startDate}&to=${endDate}`;
+    const url = [BACKEND_URL, '/', this.url, '?', `from=${params.from}`, '&', `?to=${params.to}`].join('');
+
+    return fetchJson(url, params)
+      .then(json => {
+        this.data = Object.values(json);
+        this.rerender();
+      });
+  }
 }


### PR DESCRIPTION
07.1 async load column chart
Не проходит единственный тест  "should load data correctly":
 expect(received).toEqual(expected) // deep equality
Expected: 
```
{"2020-04-11": 8, "2020-04-12": 13, "2020-04-13": 20, "2020-04-14": 15, "2020-04-15": 5, "2020-04-16": 19, "2020-04-17": 19, "2020-04-18":
 5, "2020-04-19": 14, "2020-04-20": 20, "2020-04-21": 14, "2020-04-22": 7, "2020-04-23": 22, "2020-04-24": 19, "2020-04-25": 4, "2020-04-26": 24, "2020-
04-27": 20, "2020-04-28": 4, "2020-04-29": 24, "2020-04-30": 20, "2020-05-01": 4, "2020-05-02": 24, "2020-05-03": 20, "2020-05-04": 3, "2020-05-05": 22,
 "2020-05-06": 22, "2020-05-07": 1, "2020-05-08": 21, "2020-05-09": 22, "2020-05-10": 5, "2020-05-11": 17}
```
Received: 
```
undefined
```
В моках лежит orders-data.js и этот тест вызывается, как я понял, с равными датами:
``` javascript
 it('should load data correctly', async () => {
    const from = new Date();
    const to = new Date();
    const data = await columnChart.update(from, to);

    expect(data).toEqual(ordersData);
  });
```
Этот тест хочет, чтобы вместо undefined мы подставляли данные из мока?